### PR TITLE
clarify the configuration in for storing traces in automations

### DIFF
--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -17,11 +17,11 @@ Automations created in YAML must have an [`id`](/docs/automation/yaml/#migrating
 
 #### Traces ####
 
-The last 5 traces are recorded for all automations. It is possible to change this by adding the following code to your automation.
+The last 5 traces are recorded for all automations. It is possible to change this for a single automation. For example, to store 10 traces instead of the default 5, add this to your automation:
 
 ```yaml
 trace:
-    stored_traces: 1
+    stored_traces: 10
 ```
 
 [template]: /topics/templating/


### PR DESCRIPTION
## Proposed change

It is not clear from the documentation what setting `stored_traces` to `1` means. Does it mean "keep all traces" or "keep one trace"? 

Assuming it means "keep one trace", putting a value of 10 in the documentation makes it more clear that this integer value represents the number of traces to be stored.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ x ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ x ] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
